### PR TITLE
Remove unnecessary dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "babel-plugin-transform-object-rest-spread": "^6.0.14",
     "babel-plugin-transform-react-jsx": "^6.0.14",
     "babel-plugin-transform-regenerator": "^6.0.14",
-    "babel-plugin-transform-undefined-to-void": "^6.0.14",
-    "babel-preset-es2015": "^6.0.15",
-    "babel-preset-react": "^6.0.15"
+    "babel-plugin-transform-undefined-to-void": "^6.0.14"
   }
 }


### PR DESCRIPTION
The `babel-preset` dependencies are not longer required.